### PR TITLE
Update jQuery to 3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3983,9 +3983,9 @@
       }
     },
     "jquery": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "js-yaml": {
       "version": "3.4.5",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.7",
-    "jquery": "^2.2.0",
+    "jquery": "^3.3.1",
     "merge-stream": "^1.0.0",
     "node-notifier": "^4.6.0",
     "normalize.css": "^3.0.3",


### PR DESCRIPTION
Resolves a security vulnerability from an old jQuery dependency.